### PR TITLE
Support for universal webpack 2 loader options

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,21 @@
 const when = require("when");
 const chalk = require("chalk");
 const Handlebars = require("handlebars");
+const loaderUtils = require("loader-utils");
 const log = require("./lib/log");
 const partialsMap = require("./lib/partialsMap");
 const helpersMap = require("./lib/helpersMap");
 const findPartials = require("./lib/findPartials");
 
+function getLoaderConfig(context) {
+    const query = loaderUtils.getOptions(context) || {};
+    const configKey = query.config || "handlebarsRenderLoader";
+    const config = context.options && context.options.hasOwnProperty(configKey) ? context.options[configKey] : {};
+
+    delete query.config;
+
+    return Object.assign(query, config);
+}
 
 function handlebarsRenderLoader(content) {
     const loaderApi = this;
@@ -15,7 +25,7 @@ function handlebarsRenderLoader(content) {
         {
             helpers: {}
         },
-        loaderApi.options.handlebarsRenderLoader || {}
+        getLoaderConfig(this) || {}
     );
     const partialAliases = Object.keys(config.partialAliases || {});
     const partialAliasesPaths = config.partialAliases ? partialAliases.map((partialAlias) =>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chalk": "^1.1.1",
     "glob": "^7.0.5",
     "handlebars": "^4.0.5",
-    "loader-utils": "^0.2.17",
+    "loader-utils": "^1.0.2",
     "when": "^3.7.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "keywords": [],
   "author": "szig-*",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "chalk": "^1.1.1",
     "glob": "^7.0.5",
     "handlebars": "^4.0.5",
-    "loader-utils": "^0.2.12",
+    "loader-utils": "^0.2.17",
     "when": "^3.7.7"
   },
   "devDependencies": {
@@ -26,6 +26,5 @@
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
Standard loader options can be used instead of defining `handlebarsRenderLoader` prop on webpack config, which is not allowed in webpack 2


Usage example:

```
module: {
    rules: [
      {
          test: /\.hbs$/,
          use: [
            {
              loader: 'file-loader',
              options: {
                name: 'index.html'
              }
            },
            'extract-loader',
            'html-loader',
            {
              loader: `handlebars-render-loader`,
              options: {
                data: require('./data/test.json')
              }
            }
          ]
      }
}
```
